### PR TITLE
Use exec in sh -c to propagate signals to pane commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ impl ZellijPlugin for ZellijForeman {
             open_command_pane(
                 CommandToRun {
                     path: PathBuf::from("sh"),
-                    args: vec!["-c".to_string(), command.to_string()],
+                    args: vec!["-c".to_string(), format!("exec {}", command)],
                     cwd: Some(cwd.clone()),
                 },
                 BTreeMap::new(),


### PR DESCRIPTION
## Summary
- Prepend \`exec\` to the \`sh -c\` argument so the shell is replaced by the user's command
- Fixes inconsistent cleanup on Ctrl+q (e.g. \`docker run\` containers sometimes surviving) caused by \`sh\` swallowing signals when it forks instead of execs

## Test plan
- [ ] Put a \`docker run --rm ...\` entry in a Procfile, launch the plugin, press Ctrl+q, confirm the container exits every time
- [ ] Verify simple commands (e.g. \`npm start\`) still run normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)